### PR TITLE
feat: add a --debug flag to add debug options

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,13 +7,20 @@ The WireCraft project!
 > [!IMPORTANT]
 > The project requires Python >= 3.12 !
 
-> [!WARNING]
-> This installation method doesn't work for now.
-
+Using pip:
 ```bash
 pip install git+https://github.com/wirecraft-team/wirecraft.git -U
 wirecraft
 ```
+
+Using uvx:
+```bash
+uvx --from https://github.com/wirecraft-team/wirecraft.git wirecraft
+```
+
+### Debug options
+
+- `show_center`: add a red square at position 0,0 in the map
 
 ## Development instructions
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,6 +3,7 @@ name = "wirecraft"
 version = "0.1b0"
 requires-python = ">=3.12"
 dependencies = [
+    "click>=8.1.8",
     "pygame-ce>=2.5.2",
     "sqlmodel",
 ]

--- a/src/wirecraft/__main__.py
+++ b/src/wirecraft/__main__.py
@@ -2,10 +2,12 @@ import ctypes
 import json
 import platform
 
+import click
+
 from wirecraft.client.game import Game, Gamestate
 from wirecraft.client.ui import Resolution
 from wirecraft.server import Server
-from wirecraft.shared_context import server_var
+from wirecraft.shared_context import ctx, server_var
 
 
 def init_game():
@@ -31,7 +33,13 @@ def init_server():
     return server
 
 
-def main():
+@click.command()
+@click.option(
+    "--debug", "-d", "debug_options", multiple=True, default=[], envvar="DEBUG", help="Enable debug mode options."
+)
+def main(debug_options: list[str]):
+    ctx.set(debug_options=debug_options)
+
     server = init_server()
     server.start()
     server_var.set(server)

--- a/src/wirecraft/client/game.py
+++ b/src/wirecraft/client/game.py
@@ -6,7 +6,7 @@ from typing import Literal
 
 import pygame
 
-from wirecraft.shared_context import server_var
+from wirecraft.shared_context import ctx, server_var
 
 from .constants import BLACK, FLAGS, FPS, GREY, PADDING, RED, RES_LIST, WHITE
 from .server_interface import ServerInterface
@@ -352,14 +352,14 @@ class Game:
         debug_text = pygame.font.Font(None, 30).render(f"Placing Cable: {self.is_placing_cable}", True, BLACK)
         self.displaysurf.blit(debug_text, (10, 10))
 
-        rect = pygame.Rect(0, 0, 10, 10)
-        rect.center = self.camera.world_to_screen((0, 0), self.resolution.size)
-
-        pygame.draw.rect(
-            self.displaysurf,
-            RED,
-            rect,
-        )
+        if "show_center" in ctx.debug_options:
+            rect = pygame.Rect(0, 0, 10, 10)
+            rect.center = self.camera.world_to_screen((0, 0), self.resolution.size)
+            pygame.draw.rect(
+                self.displaysurf,
+                RED,
+                rect,
+            )
 
     def updateview(self) -> None:
         if self.view == Gamestate.MENU:

--- a/src/wirecraft/shared_context.py
+++ b/src/wirecraft/shared_context.py
@@ -1,9 +1,29 @@
 from __future__ import annotations
 
+from collections.abc import Sequence
 from contextvars import ContextVar
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     from wirecraft.server.server import Server
 
 server_var: ContextVar[Server] = ContextVar("server")
+
+
+class Context:
+    instance: Context | None = None
+
+    def __new__(cls, *args: Any, **kwargs: Any) -> Context:  # noqa: PYI034
+        if cls.instance is None:
+            cls.instance = super().__new__(cls, *args, **kwargs)
+        return cls.instance
+
+    def __init__(self):
+        self.debug_options: Sequence[str] = []
+
+    def set(self, debug_options: Sequence[str] | None = None) -> None:
+        if debug_options is not None:
+            self.debug_options = debug_options
+
+
+ctx = Context()

--- a/uv.lock
+++ b/uv.lock
@@ -38,6 +38,18 @@ wheels = [
 ]
 
 [[package]]
+name = "click"
+version = "8.1.8"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b9/2e/0090cbf739cee7d23781ad4b89a9894a41538e4fcf4c31dcdd705b78eb8b/click-8.1.8.tar.gz", hash = "sha256:ed53c9d8990d83c2a27deae68e4ee337473f6330c040a31d4225c9574d16096a", size = 226593 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7e/d4/7ebdbd03970677812aac39c869717059dbb71a4cfc033ca6e5221787892c/click-8.1.8-py3-none-any.whl", hash = "sha256:63c132bbbed01578a06712a2d1f497bb62d9c1c0d329b7903a866228027263b2", size = 98188 },
+]
+
+[[package]]
 name = "colorama"
 version = "0.4.6"
 source = { registry = "https://pypi.org/simple" }
@@ -455,6 +467,7 @@ name = "wirecraft"
 version = "0.1b0"
 source = { editable = "." }
 dependencies = [
+    { name = "click" },
     { name = "pygame-ce" },
     { name = "sqlmodel" },
 ]
@@ -471,6 +484,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "click", specifier = ">=8.1.8" },
     { name = "pygame-ce", specifier = ">=2.5.2" },
     { name = "sqlmodel" },
 ]


### PR DESCRIPTION
You can now run wirecraft with the option `wirecraft -d show_center` to enable the center red square.

You can combine debug options with multiple `-d` flags. 