### PR TITLE
I hate the KISS principle. :)

### DIFF
--- a/src/wirecraft/client/game.py
+++ b/src/wirecraft/client/game.py
@@ -10,8 +10,7 @@ from wirecraft.shared_context import ctx, server_var
 
 from .constants import BLACK, FLAGS, FPS, GREY, PADDING, RED, RES_LIST, WHITE
 from .server_interface import ServerInterface
-from .ui import Button, Cable, Camera, Device, Resolution, Window
-from .ui.assets import INVENTORY_BUTTON
+from .ui import Assets, Button, Cable, Camera, Device, Resolution, Window
 
 
 class Gamestate(Enum):
@@ -35,6 +34,7 @@ class Game:
         self.server = ServerInterface(self)
         self.resolution = resolution
         self.displaysurf = pygame.display.set_mode(self.resolution.size, FLAGS)
+        Assets.load_assets()
         self.camera = Camera(self)
         # Example: get the money
         self.server.get_money()
@@ -57,7 +57,7 @@ class Game:
                 (0 + PADDING, self.resolution.height - 100 - PADDING),
                 (100, 100),
                 self.show_inventory,
-                INVENTORY_BUTTON,
+                Assets.INVENTORY_BUTTON,
             )
         )
 

--- a/src/wirecraft/client/ui/__init__.py
+++ b/src/wirecraft/client/ui/__init__.py
@@ -1,3 +1,4 @@
+from .assets import Assets as Assets
 from .button import Button as Button
 from .cable import Cable as Cable
 from .camera import Camera as Camera

--- a/src/wirecraft/client/ui/assets.py
+++ b/src/wirecraft/client/ui/assets.py
@@ -1,16 +1,9 @@
-import os
-from importlib.resources import files
+from .assets_meta import Asset, AssetsMeta
 
-import pygame
 
-# Check for assets in the package if installed
-assets_dir = str(files("wirecraft").joinpath("assets"))
-
-# Otherwise check on the local directory if executed in dev environnement
-if not os.path.exists(assets_dir):
-    assets_dir = "./assets"
-
-SWITCH_DEVICE = pygame.image.load_sized_svg(f"{assets_dir}/switch.svg", (18910, 1660))
-PC_DEVICE = pygame.image.load(f"{assets_dir}/pc.png")
-CLOSE_BUTTON = pygame.image.load(f"{assets_dir}/close.png")
-INVENTORY_BUTTON = pygame.image.load(f"{assets_dir}/inventory.png")
+class Assets(metaclass=AssetsMeta):
+    SWITCH_DEVICE = Asset("switch.png")
+    # SWITCH_DEVICE = pygame.image.load_sized_svg(f"switch.svg", (18910, 1660))
+    PC_DEVICE = Asset("pc.png")
+    CLOSE_BUTTON = Asset("close.png")
+    INVENTORY_BUTTON = Asset("inventory.png")

--- a/src/wirecraft/client/ui/assets.py
+++ b/src/wirecraft/client/ui/assets.py
@@ -1,9 +1,8 @@
-from .assets_meta import Asset, AssetsMeta
+from .assets_meta import Asset, AssetsMeta, SvgAsset
 
 
 class Assets(metaclass=AssetsMeta):
-    SWITCH_DEVICE = Asset("switch.png")
-    # SWITCH_DEVICE = pygame.image.load_sized_svg(f"switch.svg", (18910, 1660))
+    SWITCH_DEVICE = SvgAsset("switch.svg", (18910, 1660))
     PC_DEVICE = Asset("pc.png")
     CLOSE_BUTTON = Asset("close.png")
     INVENTORY_BUTTON = Asset("inventory.png")

--- a/src/wirecraft/client/ui/assets_meta.py
+++ b/src/wirecraft/client/ui/assets_meta.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+from importlib.resources import files
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+import pygame
+
+from ..utils import SingletonMeta
+
+if TYPE_CHECKING:
+    from .assets import Assets
+
+# Check for assets in the package if installed
+assets_dir = Path(str(files("wirecraft").joinpath("assets")))
+
+# Otherwise check on the local directory if executed in dev environnement
+if not assets_dir.exists():
+    assets_dir = Path("./assets")
+
+
+class AssetsMeta(SingletonMeta):
+    def __new__(cls, name: str, bases: tuple[Any], dct: dict[str, Any]):
+        dct["__assets_loaders__"] = []
+        return super().__new__(cls, name, bases, dct)
+
+    def load_assets(cls):  # noqa: N805 (false positive...)
+        for asset_loader in getattr(cls, "__assets_loaders__"):
+            asset_loader.load()
+
+
+class Asset:
+    def __init__(self, filename: str):
+        self.filename = filename
+        self._loaded_asset: pygame.Surface | None = None
+
+    def __set_name__(self, owner: Assets, name: str):
+        getattr(owner, "__assets_loaders__").append(self)
+
+    @property
+    def is_loaded(self):
+        return self._loaded_asset is not None
+
+    def load(self):
+        if not self.is_loaded:
+            self._loaded_asset = pygame.image.load(assets_dir / self.filename).convert_alpha()
+            print(f"Loaded {self.filename}")
+        else:
+            print(f"{self.filename} is already loaded !")
+
+    def __get__(self, instance: Assets | None, owner: type[Assets]) -> pygame.Surface:
+        if not self.is_loaded:
+            self.load()
+
+        if TYPE_CHECKING:
+            assert self._loaded_asset is not None
+
+        return self._loaded_asset

--- a/src/wirecraft/client/ui/assets_meta.py
+++ b/src/wirecraft/client/ui/assets_meta.py
@@ -1,3 +1,11 @@
+"""
+assets_meta.py contains the "secrets" classes that make the assets.py file work "magically".
+This code is "private" in the sense that it is not meant to be used outside assets.py.
+
+This code use Metaclasses and Descriptors. These are advanced Python features that I will not explain here to avoid
+verbose explanations.
+"""
+
 from __future__ import annotations
 
 from importlib.resources import files
@@ -20,6 +28,14 @@ if not assets_dir.exists():
 
 
 class AssetsMeta(SingletonMeta):
+    """
+    A metaclass that defined the underlying class as a singleton (only one instance of the class can exist) and also
+    add a attribute to the class that will store all the assets loaders.
+
+    The assets loaders are the instances of the Asset class that are defined in the class body.
+    The class also provide a method to load all the assets.
+    """
+
     def __new__(cls, name: str, bases: tuple[Any], dct: dict[str, Any]):
         dct["__assets_loaders__"] = []
         return super().__new__(cls, name, bases, dct)
@@ -30,6 +46,14 @@ class AssetsMeta(SingletonMeta):
 
 
 class Asset:
+    """
+    An Asset is a descriptor that will lazy-load the asset on access-time.
+    That means that the asset is not loaded at definition time but when it is accessed for the first time
+
+    Alternatively, the Asset can be loaded using the Descriptor load() method, but this method is not easily accessible.
+    You should use the AssetsMeta.load_assets() method to load all the assets at once.
+    """
+
     def __init__(self, filename: str):
         self.filename = filename
         self._loaded_asset: pygame.Surface | None = None
@@ -56,3 +80,20 @@ class Asset:
             assert self._loaded_asset is not None
 
         return self._loaded_asset
+
+
+class SvgAsset(Asset):
+    """
+    Same as Asset but to load SVG files (with a specific size).
+    """
+
+    def __init__(self, filename: str, size: tuple[int, int]):
+        super().__init__(filename)
+        self.size = size
+
+    def load(self):
+        if not self.is_loaded:
+            self._loaded_asset = pygame.image.load_sized_svg(assets_dir / self.filename, self.size).convert_alpha()
+            print(f"Loaded {self.filename}")
+        else:
+            print(f"{self.filename} is already loaded !")

--- a/src/wirecraft/client/ui/device.py
+++ b/src/wirecraft/client/ui/device.py
@@ -4,7 +4,7 @@ from typing import TYPE_CHECKING
 
 from wirecraft.client.ui.extended_sprite import ExtendedSprite
 
-from .assets import SWITCH_DEVICE
+from . import Assets
 
 if TYPE_CHECKING:
     from ..game import Game
@@ -15,4 +15,4 @@ class Device(ExtendedSprite):
         """
         Position is the point in the world map that refer to the center of the device.
         """
-        super().__init__(game, position, SWITCH_DEVICE)
+        super().__init__(game, position, Assets.SWITCH_DEVICE)

--- a/src/wirecraft/client/ui/window.py
+++ b/src/wirecraft/client/ui/window.py
@@ -3,7 +3,7 @@ from dataclasses import dataclass
 import pygame
 
 from ..constants import BLACK, GREY
-from .assets import CLOSE_BUTTON
+from . import Assets
 
 
 @dataclass
@@ -33,7 +33,7 @@ class Window:
         """Draws a windows according to the position and size attributes. Coordinates are screen coordinates. (top left corner is (0, 0))"""
         window = pygame.Surface(self.size)
         window.fill(GREY)
-        close_button = pygame.transform.scale(CLOSE_BUTTON, (25, 25))
+        close_button = pygame.transform.scale(Assets.CLOSE_BUTTON, (25, 25))
         pygame.draw.rect(window, BLACK, (0, 0, self.size[0], self.size[1]), 5)
         surface.blit(window, self.position)
         surface.blit(close_button, (self.position[0] + self.size[0] - 40, self.position[1] + 10))

--- a/src/wirecraft/client/utils.py
+++ b/src/wirecraft/client/utils.py
@@ -1,4 +1,13 @@
+from typing import Any
+
 from wirecraft.client.ui.camera import ObjectBounds
+
+
+class SingletonMeta(type):
+    def __call__(cls, *args: Any, **kwargs: Any):
+        if not hasattr(cls, "_instance"):
+            cls._instance = super().__call__(*args, **kwargs)
+        return cls._instance
 
 
 def intersect_bounds(object1: ObjectBounds, object2: ObjectBounds):

--- a/src/wirecraft/client/utils.py
+++ b/src/wirecraft/client/utils.py
@@ -4,6 +4,22 @@ from wirecraft.client.ui.camera import ObjectBounds
 
 
 class SingletonMeta(type):
+    """
+    This is a Metaclass to transform a class into a Singleton.
+
+    A Singleton is a class that can only have one instance at a time.
+
+    For example:
+    ```py
+    class MyClass(metaclass=SingletonMeta):
+        pass
+
+    a = MyClass()
+    b = MyClass()
+    assert a is b  # True
+    ```
+    """
+
     def __call__(cls, *args: Any, **kwargs: Any):
         if not hasattr(cls, "_instance"):
             cls._instance = super().__call__(*args, **kwargs)


### PR DESCRIPTION
Add Asset lazy-loading, so the assets are loaded after the screen is initialized (this allow to optimize the asset for Pygame to blit them faster)

This is divised in two part : assets_meta.py that contain more "internal" code to allow the assets.py file to be simple to use!