### PR TITLE
Make the database path customizable (useful for Docker)

### DIFF
--- a/python/compose.yaml
+++ b/python/compose.yaml
@@ -2,10 +2,12 @@ services:
   wirecraft-server:
     hostname: wirecraft-server
     init: true
+    environment:
+      - DATABASE=data/database.db
     build:
       context: .
       target: production
     ports:
       - 8765:8765
     volumes:
-      - $PWD/database.db:/app/database.db
+      - $PWD/data:/app/data

--- a/python/src/wirecraft_server/__main__.py
+++ b/python/src/wirecraft_server/__main__.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 import click
 
 from wirecraft_server._logger import init_logger
@@ -16,8 +18,17 @@ def init_server():
 )
 @click.option("--log-level", "-l", "log_level", default="INFO", envvar="LOG_LEVEL", help="Set the log level.")
 @click.option("--bind", "-b", "bind", default="localhost", envvar="BIND", help="Set the bind interface.")
-def main(debug_options: list[str], log_level: str, bind: str):
-    ctx.set(debug_options=debug_options, bind=bind)
+@click.option(
+    "--database",
+    "-D",
+    "database",
+    default="database.db",
+    envvar="DATABASE",
+    help="Set the database file.",
+    type=click.Path(file_okay=True, dir_okay=False, writable=True, resolve_path=True),
+)
+def main(debug_options: list[str], log_level: str, bind: str, database: str):
+    ctx.set(debug_options=debug_options, bind=bind, database=Path(database))
     init_logger(log_level)
 
     server = init_server()

--- a/python/src/wirecraft_server/context.py
+++ b/python/src/wirecraft_server/context.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Sequence
+from pathlib import Path
 from typing import Any
 
 MISSING: Any = object()
@@ -17,10 +18,12 @@ class Context:
     def __init__(self):
         self.debug_options: Sequence[str] = MISSING
         self.bind = MISSING
+        self.database = MISSING
 
-    def set(self, debug_options: Sequence[str], bind: str) -> None:
+    def set(self, debug_options: Sequence[str], bind: str, database: Path) -> None:
         self.debug_options = debug_options
         self.bind = bind
+        self.database = database
 
 
 ctx = Context()

--- a/python/src/wirecraft_server/database/__init__.py
+++ b/python/src/wirecraft_server/database/__init__.py
@@ -1,10 +1,11 @@
+from sqlalchemy.ext.asyncio import AsyncEngine
 from sqlmodel import SQLModel
 
 from .models import Cable as Cable, Device as Device, LevelState as LevelState
-from .session import async_session as async_session, engine
+from .session import async_session as async_session
 
 
-async def init_db():
+async def init_db(engine: AsyncEngine):
     """
     TODO(airopi): stop destroying the database on every start.
     """

--- a/python/src/wirecraft_server/database/session.py
+++ b/python/src/wirecraft_server/database/session.py
@@ -1,8 +1,4 @@
-from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+from sqlalchemy.ext.asyncio import async_sessionmaker
 from sqlmodel.ext.asyncio.session import AsyncSession
 
-db = "sqlite+aiosqlite:///database.db"
-engine = create_async_engine(db)
-
-
-async_session = async_sessionmaker(bind=engine, class_=AsyncSession, expire_on_commit=False)
+async_session = async_sessionmaker(class_=AsyncSession, expire_on_commit=False)


### PR DESCRIPTION
The volume of compose.yaml was directly the db file, but if file doesn't exist, Docker create a **directory** (not a file), so the server can't create the database.

This PR introduce a --database PATH.

*Should be merged after #44*